### PR TITLE
fix and improve metadata handling

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"manifest_version": 2,
 	"name": "SoundCloud Downloader",
-	"version": "2.1",
+	"version": "2.2",
 	"description": "Download SoundCloud songs as mp3s with normalized metadata.",
 	"homepage_url": "https://github.com/nyo/scdl",
 	"icons": {


### PR DESCRIPTION
changelog:
- [x] fixed a bug where download of songs with no description did not work (closes https://github.com/nyo/scdl/issues/7)
- [x] added support for `publisher_metadata` which is metadata entered by the person uploading the music (= more reliable)
  - now uses `publisher_metadata.artist` before `user.username` for artist name
  - now uses `publisher_metadata.release_title` before `title` for song title
  - now uses `release_date` before `created_at` for album release year
  - now uses `publisher_metadata.writer_composer` for song composer name